### PR TITLE
Ignore sourcemaps names

### DIFF
--- a/lib/fromStringWithSourceMap.js
+++ b/lib/fromStringWithSourceMap.js
@@ -62,8 +62,9 @@ module.exports = function fromStringWithSourceMap(code, map) {
 			var linePosition = currentLine;
 		}
 
-		if(mapping.rest && mapping.rest[0] === ",") {
-			mapping.rest = mapping.rest.substr(1);
+		if(mapping.rest) {
+			var next = mapping.rest.indexOf(",");
+			mapping.rest = next === -1 ? "" : mapping.rest.substr(next);
 		}
 
 		if(!ignore) {


### PR DESCRIPTION
Hi,

Since babel landed their 6.4 version, our project is having difficulties getting correct sourcemaps, breakpoints not stopping, console.log pointing to undefined webpack files, ...

It seems the addition of names into the sourcemaps (https://github.com/babel/babel/pull/3658) which adds an extra character is unsupported by this module. I went for a really quick and dumb fix, which is to completely ignore the extra character, but maybe someone could give me some guidance about supporting it if it's desired ?

Regards.
